### PR TITLE
VSSL-6825 Add finetuning llama 2

### DIFF
--- a/llama2-finetuning/README.md
+++ b/llama2-finetuning/README.md
@@ -1,0 +1,24 @@
+# Finetuning Llama2
+
+Finetuning Llama 2 with a small code instruction dataset in Alpaca format
+
+## Description
+
+Llama 2 is a large language model (LLM) developed by Meta. It is open-sourced with codes and various weights pre-trained and finetuned on, varying in size of parameter counts from 7 billion to 70 billion. In this repository, llama 2 7B model will be finetuned on a code instruction dataset which consists of 18k samples and is in format of Alpaca instruction. 
+
+While training, learning rate, training loss and validation loss will be logged on `Plots` page.
+
+## Quickstart
+
+Modify `config.yaml` to your own configuration and run following:
+
+```sh
+pip install -r requirements.txt
+python finetuning.py
+```
+
+## Reference
+
+ - Arxiv: <https://arxiv.org/abs/2307.09288>
+ - Blog: <https://ai.meta.com/resources/models-and-libraries/llama/>
+ - Repo: <https://github.com/facebookresearch/llama>

--- a/llama2-finetuning/config.yaml
+++ b/llama2-finetuning/config.yaml
@@ -1,21 +1,24 @@
+# model
 model_name: /model_/llama_2_7b_hf
 quantization: true
 
 # dataset
-dataset_path: /dataset/code_instructions_18k_alpaca
+dataset_path: /dataset/
 
 # training
-training_config:
-  batch_size: 4
+training:
+  batch_size: 8
   grad_acc_steps: 1
   learning_rate: 3e-4
-  warm_up_steps: 10000
+  use_fp16: true
+  warmup_steps: 100
+  # max_steps: 20000
   num_train_epochs: 3
   evaluation_strategy: steps
   save_strategy: steps
-  logging_steps: 100
-  eval_steps: 1000
-  save_steps: 1000
+  logging_steps: 5
+  eval_steps: 25
+  save_steps: 25
   save_limit: 5
   output_dir: /trained_model/
   intermediate_dir: /artifacts/

--- a/llama2-finetuning/finetuning.py
+++ b/llama2-finetuning/finetuning.py
@@ -1,0 +1,120 @@
+import torch
+import vessl
+from datasets import load_from_disk
+from omegaconf import OmegaConf
+from peft import get_peft_config, get_peft_model, prepare_model_for_int8_training
+from transformers import (
+    DataCollatorForSeq2Seq,
+    LlamaForCausalLM,
+    LlamaTokenizer,
+    Trainer,
+    TrainerCallback,
+    TrainingArguments,
+)
+
+train_config = OmegaConf.load("./train_config.yaml")
+
+model = LlamaForCausalLM.from_pretrained(
+    train_config.model_name,
+    load_in_8bit=True if train_config.quantization else None,
+    device_map="auto" if train_config.quantization else None,
+)
+
+tokenizer = LlamaTokenizer.from_pretrained(train_config.model_name)
+tokenizer.pad_token = tokenizer.eos_token
+tokenizer.padding_side = "right"
+
+
+if train_config.quantization:
+    model = prepare_model_for_int8_training(model)
+
+if train_config.peft.enable:
+    peft_config = get_peft_config(OmegaConf.to_container(train_config.peft.config))
+    model = get_peft_model(model, peft_config)
+
+
+# dataset
+def tokenize(sample, add_eos_token=True):
+    prompt = sample["prompt"]
+
+    result = tokenizer(
+        prompt,
+        truncation=True,
+        max_length=256,
+        padding=False,
+        return_tensors=None,
+    )
+    if (
+        result["input_ids"][-1] != tokenizer.eos_token_id
+        and len(result["input_ids"]) < 256
+        and add_eos_token
+    ):
+        result["input_ids"].append(tokenizer.eos_token_id)
+        result["attention_mask"].append(1)
+
+    result["labels"] = result["input_ids"].copy()
+
+    return result
+
+
+ds = load_from_disk(train_config.dataset_path)
+processed_ds = ds.map(tokenize)
+
+data_collator = DataCollatorForSeq2Seq(
+    tokenizer, pad_to_multiple_of=8, return_tensors="pt", padding=True
+)
+
+
+training_arguments = TrainingArguments(
+    per_device_train_batch_size=train_config.batch_size,
+    gradient_accumulation_steps=train_config.grad_acc_steps,
+    warmup_steps=train_config.warmup_steps,
+    num_train_epochs=train_config.num_train_epochs,
+    # max_steps=train_config.max_steps,
+    learning_rate=train_config.learning_rate,
+    fp16=True,
+    logging_steps=train_config.logging_steps,
+    evaluation_strategy="steps",
+    save_strategy="steps",
+    eval_steps=train_config.eval_steps,
+    save_steps=train_config.save_steps,
+    output_dir=train_config.intermediate_dir,
+    save_total_limit=5,
+    load_best_model_at_end=True,
+)
+
+
+class VesslLogCallback(TrainerCallback):
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        if "eval_loss" in logs.keys():
+            payload = {
+                "eval_loss": logs["eval_loss"],
+            }
+            vessl.log(step=state.global_step, payload=payload)
+        elif "loss" in logs.keys():
+            payload = {
+                "train_loss": logs["loss"],
+                "learning_rate": logs["learning_rate"],
+            }
+            vessl.log(step=state.global_step, payload=payload)
+
+
+trainer = Trainer(
+    model=model,
+    train_dataset=processed_ds["train"],
+    eval_dataset=processed_ds["validation"],
+    args=training_arguments,
+    data_collator=data_collator,
+    callbacks=[VesslLogCallback],
+)
+model.config.use_cache = False
+
+# old_state_dict = model.state_dict
+# model.state_dict = (
+#     lambda self, *_, **__: get_peft_model_state_dict(self, old_state_dict())
+# ).__get__(model, type(model))
+
+model = torch.compile(model)
+trainer.train()
+
+model.save_pretrained(train_config.output_dir)

--- a/llama2-finetuning/requirements.txt
+++ b/llama2-finetuning/requirements.txt
@@ -1,0 +1,15 @@
+accelerate==0.24.1
+antlr4-python3-runtime==4.9.3
+bitsandbytes==0.41.2.post2
+datasets==2.15.0
+dill==0.3.7
+huggingface-hub==0.19.4
+multiprocess==0.70.15
+omegaconf==2.3.0
+peft==0.6.2
+pyarrow-hotfix==0.6
+safetensors==0.4.1
+sentencepiece==0.1.99
+tokenizers==0.15.0
+transformers==4.35.2
+xxhash==3.4.1

--- a/llama2-finetuning/train_config.yaml
+++ b/llama2-finetuning/train_config.yaml
@@ -1,0 +1,34 @@
+model_name: /model_/llama_2_7b_hf
+quantization: true
+
+# dataset
+dataset_path: /dataset/code_instructions_18k_alpaca
+
+# training
+training_config:
+  batch_size: 4
+  grad_acc_steps: 1
+  learning_rate: 3e-4
+  warm_up_steps: 10000
+  num_train_epochs: 3
+  evaluation_strategy: steps
+  save_strategy: steps
+  logging_steps: 100
+  eval_steps: 1000
+  save_steps: 1000
+  save_limit: 5
+  output_dir: /trained_model/
+  intermediate_dir: /artifacts/
+
+# lora config
+peft:
+  enable: true
+  config:
+    peft_type: LORA
+    task_type: CAUSAL_LM
+    inference_mode: false
+    r: 8
+    target_modules: [q_proj, v_proj]
+    lora_alpha: 16
+    lora_dropout: 0.05
+    bias: none


### PR DESCRIPTION
Alpaca 형식의 code instruction set을 이용하여 llama 2를 finetuning하는 예제입니다.

```yaml
name: llama2-finetuning
description: finetune llama2 with code instruction alpaca dataset
resources:
  cluster: google-oregon
  preset: v1.l4-1.mem-27
image: quay.io/vessl-ai/ngc-pytorch-kernel:23.10-py3-202311150327
import:
  /model/: vessl-model://vessl-ai/llama2/1
  /code/:
    git:
      url: https://github.com/vessl-ai/hub-model
      ref: main
  /dataset/: vessl-dataset://vessl-ai/code_instructions_small_alpaca
export:
  /trained_model/: vessl-model://vessl-ai/llama2-finetuned
  /artifacts/: vessl-artifact://
run:
  - command: |-
      pip install -r requirements.txt
      mkdir /model_
      cd /model
      mv llama_2_7b_hf.zip /model_
      cd /model_
      unzip llama_2_7b_hf.zip
      cd /code/llama2-finetuning
      python finetuning.py
    workdir: /code/llama2-finetuning
```